### PR TITLE
Always load data to "now"

### DIFF
--- a/consumption_exporter.py
+++ b/consumption_exporter.py
@@ -31,7 +31,7 @@ def _get_query_date_range(connection, series):
         latest_time = result.raw['series'][0]['values'][0][0]
         click.echo(f"Latest entry for series {series} is on {latest_time}.")
         from_date = parser.parse(latest_time)
-        to_date = from_date + timedelta(days=1)
+        to_date = datetime.now()
         return from_date.isoformat(), to_date.isoformat()
     else:
         # DB empty (i.e. running first time) or something wrong with series. Drop series if data already there.


### PR DESCRIPTION
Previously after the initial load the daily load would only request data for the 24 hours after the most recent entry in the series. That works most of the time but when the container is stopped (crash or external issue) it doesn't catch up when restarted, but required manually restarting until all missed data was requested one day at a time. This change updates the to_date on the request to "now" so missed data is retrieved on the next load.